### PR TITLE
fix: AI 피드백 카운트 매일 초기화되지 않는 에러 수정

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -92,14 +92,13 @@ export async function POST(request: Request) {
 
   // Rate limit for default key users
   if (!customApiKey) {
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
+    const utcTodayStart = new Date().toISOString().split("T")[0] + "T00:00:00.000Z";
     const { count, error: countError } = await supabase
       .from("study_records")
       .select("*", { count: "exact", head: true })
       .eq("user_id", user.id)
       .neq("feedback", "")
-      .gte("studied_at", todayStart.toISOString());
+      .gte("studied_at", utcTodayStart);
 
     if (!countError && (count ?? 0) >= DAILY_FREE_LIMIT) {
       return NextResponse.json({

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -92,13 +92,18 @@ export async function POST(request: Request) {
 
   // Rate limit for default key users
   if (!customApiKey) {
-    const utcTodayStart = new Date().toISOString().split("T")[0] + "T00:00:00.000Z";
+    // KST(UTC+9) 기준 오늘 0시를 UTC ISO 문자열로 계산
+    const now = new Date();
+    const kstNow = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+    const kstDateStr = kstNow.toISOString().split("T")[0];
+    const kstTodayStartUTC = new Date(kstDateStr + "T00:00:00+09:00").toISOString();
+
     const { count, error: countError } = await supabase
       .from("study_records")
       .select("*", { count: "exact", head: true })
       .eq("user_id", user.id)
       .neq("feedback", "")
-      .gte("studied_at", utcTodayStart);
+      .gte("studied_at", kstTodayStartUTC);
 
     if (!countError && (count ?? 0) >= DAILY_FREE_LIMIT) {
       return NextResponse.json({

--- a/app/globals.css
+++ b/app/globals.css
@@ -141,6 +141,15 @@ textarea:focus {
   text-decoration: underline;
 }
 
+/* Select dropdown options (OS-rendered) */
+select {
+  color-scheme: dark;
+}
+select option {
+  background: #18181b;
+  color: #e4e4e7;
+}
+
 /* Copy button toast */
 @keyframes fadeInOut {
   0% { opacity: 0; transform: translateY(4px); }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,14 @@ const MODEL_OPTIONS = {
 };
 
 function getToday() { return new Date().toISOString().split("T")[0]; }
-function getUTCTodayStart() { return new Date().toISOString().split("T")[0] + "T00:00:00"; }
+// KST(UTC+9) 기준 오늘 0시를 UTC ISO 문자열로 반환
+function getKSTTodayStartUTC() {
+  const now = new Date();
+  const kstOffset = 9 * 60; // KST = UTC+9
+  const kstNow = new Date(now.getTime() + kstOffset * 60 * 1000);
+  const kstDateStr = kstNow.toISOString().split("T")[0];
+  return new Date(kstDateStr + "T00:00:00+09:00").toISOString(); // "YYYY-MM-DDT15:00:00.000Z" (전날 UTC)
+}
 function formatDate(iso: string) { const d = new Date(iso); return `${d.getFullYear()}.${String(d.getMonth()+1).padStart(2,"0")}.${String(d.getDate()).padStart(2,"0")}`; }
 function loadJSON<T>(key: string, fallback: T): T { if (typeof window==="undefined") return fallback; try { const r=localStorage.getItem(key); return r?JSON.parse(r):fallback; } catch { return fallback; } }
 function saveJSON(key: string, value: unknown) { localStorage.setItem(key, JSON.stringify(value)); }
@@ -98,17 +105,17 @@ export default function Home() {
   }, [user, authLoading]);
 
   // Derived
-  const utcToday = getUTCTodayStart();
+  const kstTodayUTC = getKSTTodayStartUTC();
   const activeQuestions=QUESTIONS.filter(q=>selectedCategories.has(q.category));
   const completed=new Set(records.keys());
-  const todayIds=new Set([...records.entries()].filter(([,r])=>r.studied_at>=utcToday).map(([qid])=>qid));
+  const todayIds=new Set([...records.entries()].filter(([,r])=>r.studied_at>=kstTodayUTC).map(([qid])=>qid));
   const todayCount=todayIds.size;
   const completedInActive=activeQuestions.filter(q=>completed.has(q.id)).length;
   const bookmarkCount=QUESTIONS.filter(q=>bookmarks.has(q.id)).length;
   const totalQ=activeQuestions.length;
   const progress=totalQ>0?Math.round((completedInActive/totalQ)*100):0;
   const hasCustomKey=!!customApiKey;
-  const feedbackUsedToday=[...records.values()].filter(r=>r.feedback&&r.studied_at>=utcToday).length;
+  const feedbackUsedToday=[...records.values()].filter(r=>r.feedback&&r.studied_at>=kstTodayUTC).length;
   const feedbackRemaining=hasCustomKey?Infinity:DAILY_FREE_LIMIT-feedbackUsedToday;
   const canUseFeedback=!!user&&(hasCustomKey||feedbackRemaining>0);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ const MODEL_OPTIONS = {
 };
 
 function getToday() { return new Date().toISOString().split("T")[0]; }
+function getUTCTodayStart() { return new Date().toISOString().split("T")[0] + "T00:00:00"; }
 function formatDate(iso: string) { const d = new Date(iso); return `${d.getFullYear()}.${String(d.getMonth()+1).padStart(2,"0")}.${String(d.getDate()).padStart(2,"0")}`; }
 function loadJSON<T>(key: string, fallback: T): T { if (typeof window==="undefined") return fallback; try { const r=localStorage.getItem(key); return r?JSON.parse(r):fallback; } catch { return fallback; } }
 function saveJSON(key: string, value: unknown) { localStorage.setItem(key, JSON.stringify(value)); }
@@ -56,7 +57,6 @@ export default function Home() {
   const [showCategorySettings, setShowCategorySettings] = useState(false);
   const [showApiKeySettings, setShowApiKeySettings] = useState(false);
   const [expandedId, setExpandedId] = useState<number|null>(null);
-  const [feedbackUsedToday, setFeedbackUsedToday] = useState(0);
 
   useEffect(() => { const h=(e:MouseEvent)=>{ if(dropdownRef.current&&!dropdownRef.current.contains(e.target as Node)) setDropdownOpen(false); }; document.addEventListener("mousedown",h); return ()=>document.removeEventListener("mousedown",h); }, []);
 
@@ -81,8 +81,6 @@ export default function Home() {
       if(user){
         const [recs,bks]=await Promise.all([fetchStudyRecords(user.id),fetchBookmarks(user.id)]);
         const m=new Map<number,StudyRecord>(); recs.forEach(r=>m.set(r.question_id,r)); setRecords(m); setBookmarks(new Set(bks));
-        const todayFb = recs.filter(r => r.feedback && r.studied_at.startsWith(getToday())).length;
-        setFeedbackUsedToday(todayFb);
       } else {
         const cp=loadJSON<{qid:number;answer:string;feedback:string;date:string}[]>("guestRecords",[]);
         const m=new Map<number,StudyRecord>(); cp.forEach(r=>m.set(r.qid,{question_id:r.qid,answer:r.answer,feedback:r.feedback,studied_at:r.date})); setRecords(m);
@@ -100,15 +98,17 @@ export default function Home() {
   }, [user, authLoading]);
 
   // Derived
+  const utcToday = getUTCTodayStart();
   const activeQuestions=QUESTIONS.filter(q=>selectedCategories.has(q.category));
   const completed=new Set(records.keys());
-  const todayIds=new Set([...records.entries()].filter(([,r])=>r.studied_at.startsWith(getToday())).map(([qid])=>qid));
+  const todayIds=new Set([...records.entries()].filter(([,r])=>r.studied_at>=utcToday).map(([qid])=>qid));
   const todayCount=todayIds.size;
   const completedInActive=activeQuestions.filter(q=>completed.has(q.id)).length;
   const bookmarkCount=QUESTIONS.filter(q=>bookmarks.has(q.id)).length;
   const totalQ=activeQuestions.length;
   const progress=totalQ>0?Math.round((completedInActive/totalQ)*100):0;
   const hasCustomKey=!!customApiKey;
+  const feedbackUsedToday=[...records.values()].filter(r=>r.feedback&&r.studied_at>=utcToday).length;
   const feedbackRemaining=hasCustomKey?Infinity:DAILY_FREE_LIMIT-feedbackUsedToday;
   const canUseFeedback=!!user&&(hasCustomKey||feedbackRemaining>0);
 
@@ -178,8 +178,7 @@ export default function Home() {
       const data=await res.json();
       if(res.ok){
         setFeedback(data.feedback);
-        if(!hasCustomKey) setFeedbackUsedToday(prev=>prev+1);
-        // 피드백을 받은 즉시 DB에 저장 (새로고침해도 카운트 유지)
+        // DB에 즉시 저장 → records state 업데이트 → feedbackUsedToday 자동 재계산
         await saveRecord(currentQ.id, answer, data.feedback);
       } else {
         setFeedback(data.error||"피드백을 받지 못했습니다.");


### PR DESCRIPTION
### 🔗 관련 이슈
https://github.com/nuyeo/be-interview-questions/issues/5

### 📌 작업 내용
- 클라이언트/서버 시간 동기화 (`YYYY-MM-DDT00:00:00Z`)
- 사용한 피드백 횟수를 state에서 제거 -> 매 렌더링마다 자동 계산하도록 수정

### 🧑‍💻 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] CI/CD 변경

### 📷 관련 이미지



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily feedback quota now aligns to UTC day boundaries for consistent rate limiting worldwide.
  * Feedback usage is now derived from server-side timestamps (local counters no longer updated immediately), so remaining feedback may refresh based on backend data.

* **Style**
  * Improved dropdown styling with dark mode-friendly colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->